### PR TITLE
Remove client directive from app layout to allow metadata export

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import "./globals.css";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";


### PR DESCRIPTION
## Summary
- remove the `"use client"` directive from the root layout so it can export metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa2a8134f0832d81a9d55e5ae57dc7